### PR TITLE
Fix port number in line 30 to match Readme and change Serial.begin to 9600 for compatibility with most devices

### DIFF
--- a/HW040-Rotary-Encoder.ino
+++ b/HW040-Rotary-Encoder.ino
@@ -27,7 +27,7 @@
 #include "KY040rotary.h"
 
 // init the button
-KY040 Rotary(2, 3, 4);
+KY040 Rotary(5, 6, 7);
 
 
 void OnButtonClicked(void) {
@@ -51,7 +51,7 @@ void OnButtonRight(void) {
 
 void setup() {
   // open the serial port
-  Serial.begin(115200);
+  Serial.begin(9600);
   Serial.println("Starting...");
 
   /* Init in interrupts mode

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# KY040 rotary decoder library
-KY-040 rotary encoder library for arduino and esp8266 devices.
+# HW-040/KY-040 Rotary Encoder Library
+
+KY-040 rotary encoder library for Arduino and ESP8266 devices.
 
 ## Features
 
@@ -14,7 +15,7 @@ KY-040 rotary encoder library for arduino and esp8266 devices.
 
 ## Wiring
 
-The wiring for ESP8266 can be as follows :
+The wiring for UNO/ESP8266 can be as follows :
 
 - Vcc     --> 3.3V
 - GND     --> Ground


### PR DESCRIPTION
* Fix port number in line 30 to match the port number specified in the Readme.
* Change Serial.begin to 9600 to improve compatibility with most devices.

This commit addresses two issues:

1. The port number specified in line 30 of the code did not match the port number specified in the Readme. This could have caused problems for users who were trying to follow the instructions in the Readme.
2. The default baud rate for Serial.begin was 115200. This is a relatively high baud rate, and some devices may not be able to handle it. Changing the baud rate to 9600 will make the code more compatible with a wider range of devices.

These changes should improve the usability and compatibility of the code.